### PR TITLE
44 set debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ const ctx = createContext({ width: Number, height: Number })
 ctx.set({
   pixelRatio: 2,
   width: 1280,
-  height: 720
+  height: 720,
+  debug: true
 })
 ```
 
@@ -136,6 +137,7 @@ ctx.set({
 | `pixelRatio` | canvas resolution, can't be bigger than window.devicePixelRatio | 1       |
 | `width`      | canvas width                                                    | -       |
 | `height`     | canvas height                                                   | -       |
+| `debug`      | turn on/off debug mode with log package                         | -       |
 
 Note 1: The new size and resolution will be applied not immediately but before drawing the next frame to avoid flickering.
 

--- a/framebuffer.js
+++ b/framebuffer.js
@@ -86,7 +86,7 @@ function updateFramebuffer(ctx, framebuffer, opts) {
   }
 
   if (framebuffer.depth) {
-    if (ctx.debugMode) log('fbo attaching depth', framebuffer.depth)
+    if (ctx.debug) log('fbo attaching depth', framebuffer.depth)
     const depthAttachment = framebuffer.depth
 
     if (depthAttachment.texture.target === gl.RENDERBUFFER) {
@@ -106,7 +106,7 @@ function updateFramebuffer(ctx, framebuffer, opts) {
       )
     }
   } else {
-    if (ctx.debugMode) log('fbo deattaching depth')
+    if (ctx.debug) log('fbo deattaching depth')
     gl.framebufferRenderbuffer(
       gl.FRAMEBUFFER,
       gl.DEPTH_ATTACHMENT,

--- a/index.js
+++ b/index.js
@@ -47,6 +47,8 @@ function createContext(opts) {
     })
   }
 
+  if (opts.debug) log.enabled = true
+
   if (!opts || !opts.gl) gl = createGL(opts)
   else if (opts && opts.gl) gl = opts.gl
   assert(gl, 'pex-context: createContext failed')
@@ -344,7 +346,7 @@ function createContext(opts) {
         this.updateHeight = height
       }
 
-      log.enabled = setOpts.debug
+      if (Object.keys(setOpts).includes('debug')) log.enabled = setOpts.debug
       Object.assign(this, setOpts)
     },
     checkError: function() {


### PR DESCRIPTION
- Rename `this.debugMode` to `this.debug`
- Allow debug to be set on context creation, consequently enabling log from the start
- Refactor ctx.set to assign any option to the ctx object
- Remove debug function (and with that, all the viz.js code; not sure if it is legacy or if you want to keep some part of it?) Fix #28 

Fix #44 
