### PR TITLE
Add support for compressed texture

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,12 +437,12 @@ const buf = ctx.vertexBuffer({ data: Array }) // aka Attribute Buffer
 const buf = ctx.indexBuffer({ data: Array }) // aka Index Buffer
 ```
 
-| property | info         | type                            | default              |
-| -------- | ------------ | ------------------------------- | -------------------- |
-| `data`   | pixel data   | Array, Uint8Array, Float32Array | null                 |
-| `type`   | data type    | ctx.DataType                    | ctx.DataType.Float32 |
-| `usage`  | buffer usage | ctx.Usage                       | ctx.Usage.StaticDraw |
-| `offset` | data offset in the buffer (update only) | Number/Int      | undefined |
+| property | info                                    | type                            | default              |
+| -------- | --------------------------------------- | ------------------------------- | -------------------- |
+| `data`   | pixel data                              | Array, Uint8Array, Float32Array | null                 |
+| `type`   | data type                               | ctx.DataType                    | ctx.DataType.Float32 |
+| `usage`  | buffer usage                            | ctx.Usage                       | ctx.Usage.StaticDraw |
+| `offset` | data offset in the buffer (update only) | Number/Int                      | undefined            |
 
 ### Query
 

--- a/index.js
+++ b/index.js
@@ -352,8 +352,8 @@ function createContext(opts) {
     },
     debug: function(enabled) {
       this.debugMode = enabled
-      if (enabled) {        
-        this.debugCommands = []     
+      if (enabled) {
+        this.debugCommands = []
       }
     },
     checkError: function() {
@@ -540,7 +540,7 @@ function createContext(opts) {
       // Can those two cases be simplified to
       // 0. If pass has framebuffer, run old code
       // 1. If there is framebuffer on the stack, change nothing
-      // 2. If there is only screen framebuffer on the stack and currently bound fbo is different, change it        
+      // 2. If there is only screen framebuffer on the stack and currently bound fbo is different, change it
       if (pass.framebuffer) {
         if (state.pass.id !== pass.id) {
           if (this.debugMode)
@@ -564,7 +564,10 @@ function createContext(opts) {
           }
         }
       } else {
-        if (framebuffer == ctx.defaultState.pass.framebuffer && ctx.state.framebuffer !== framebuffer) {
+        if (
+          framebuffer == ctx.defaultState.pass.framebuffer &&
+          ctx.state.framebuffer !== framebuffer
+        ) {
           gl.bindFramebuffer(framebuffer.target, framebuffer.handle)
         }
       }
@@ -1025,7 +1028,7 @@ function createContext(opts) {
       }
     },
     submit: function(cmd, batches, subCommand) {
-      if (this.debugMode) {                
+      if (this.debugMode) {
         checkProps(allowedCommandProps, cmd)
         if (batches && subCommand) {
           log('submit', cmd.name || cmd.id, {

--- a/index.js
+++ b/index.js
@@ -172,15 +172,94 @@ function createContext(opts) {
     LinearMipmapLinear: gl.LINEAR_MIPMAP_LINEAR
   }
 
+  const TextureFormat = {
+    // Unsized Internal Formats
+    RGB: [gl.RGB, DataType.Uint8], // gl.UNSIGNED_SHORT_5_6_5
+    RGBA: [gl.RGBA, DataType.Uint8], // gl.UNSIGNED_SHORT_4_4_4_4, gl.UNSIGNED_SHORT_5_5_5_1
+    LUMINANCE_ALPHA: [gl.LUMINANCE_ALPHA, DataType.Uint8],
+    LUMINANCE: [gl.LUMINANCE, DataType.Uint8],
+    ALPHA: [gl.ALPHA, DataType.Uint8],
+
+    // Sized internal formats
+    R8: [gl.RED, DataType.Uint8],
+    R8_SNORM: [gl.RED, DataType.Int8],
+    R16F: [gl.RED, DataType.Float16], // DataType.Float32
+    R32F: [gl.RED, DataType.Float32],
+
+    R8UI: [gl.RED_INTEGER, DataType.Uint8],
+    R8I: [gl.RED_INTEGER, DataType.Int8],
+    R16UI: [gl.RED_INTEGER, DataType.Uint16],
+    R16I: [gl.RED_INTEGER, DataType.Int16],
+    R32UI: [gl.RED_INTEGER, DataType.Uint32],
+    R32I: [gl.RED_INTEGER, DataType.Int32],
+
+    RG8: [gl.RG, DataType.Uint8],
+    RG8_SNORM: [gl.RG, DataType.Int8],
+    RG16F: [gl.RG, DataType.Float16], // DataType.Float32
+    RG32F: [gl.RG, DataType.Float32],
+
+    RG8UI: [gl.RG_INTEGER, DataType.Uint8],
+    RG8I: [gl.RG_INTEGER, DataType.Int8],
+    RG16UI: [gl.RG_INTEGER, DataType.Uint16],
+    RG16I: [gl.RG_INTEGER, DataType.Int16],
+    RG32UI: [gl.RG_INTEGER, DataType.Uint32],
+    RG32I: [gl.RG_INTEGER, DataType.Int32],
+
+    RGB8: [gl.RGB, DataType.Uint8],
+    SRGB8: [gl.RGB, DataType.Uint8],
+    RGB565: [gl.RGB, gl.UNSIGNED_SHORT_5_6_5], // DataType.Uint8
+    RGB8_SNORM: [gl.RGB, DataType.Int8],
+    R11F_G11F_B10F: [gl.RGB, gl.UNSIGNED_INT_10F_11F_11F_REV], // DataType.Float16, DataType.Float32
+    RGB9_E5: [gl.RGB, gl.UNSIGNED_INT_5_9_9_9_REV], // DataType.Float16, DataType.Float32
+    RGB16F: [gl.RGB, DataType.Float16], // DataType.Float32
+    RGB32F: [gl.RGB, DataType.Float32],
+
+    RGB8UI: [gl.RGB_INTEGER, DataType.Uint8],
+    RGB8I: [gl.RGB_INTEGER, DataType.Int8],
+    RGB16UI: [gl.RGB_INTEGER, DataType.Uint16],
+    RGB16I: [gl.RGB_INTEGER, DataType.Int16],
+    RGB32UI: [gl.RGB_INTEGER, DataType.Uint32],
+    RGB32I: [gl.RGB_INTEGER, DataType.Int32],
+
+    RGBA8: [gl.RGBA, DataType.Uint8],
+    SRGB8_ALPHA8: [gl.RGBA, DataType.Uint8],
+    RGBA8_SNORM: [gl.RGBA, DataType.Int8],
+    RGB5_A1: [gl.RGBA, gl.UNSIGNED_SHORT_5_5_5_1], // DataType.Uint8, gl.UNSIGNED_INT_2_10_10_10_REV
+    RGBA4: [gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4], // DataType.Uint8
+    RGB10_A2: [gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV],
+    RGBA16F: [gl.RGBA, DataType.Float32],
+    RGBA32F: [gl.RGBA, DataType.Float32],
+
+    RGBA8UI: [gl.RGBA_INTEGER, DataType.Uint8],
+    RGBA8I: [gl.RGBA_INTEGER, DataType.Int8],
+    RGB10_A2UI: [gl.RGBA_INTEGER, gl.UNSIGNED_INT_2_10_10_10_REV],
+    RGBA16UI: [gl.RGBA_INTEGER, DataType.Uint16],
+    RGBA16I: [gl.RGBA_INTEGER, DataType.Int16],
+    RGBA32I: [gl.RGBA_INTEGER, DataType.Int32],
+    RGBA32UI: [gl.RGBA_INTEGER, DataType.Uint32],
+
+    // Depth and stencil
+    DEPTH_COMPONENT16: [gl.DEPTH_COMPONENT, DataType.Uint16], // DataType.Uint32
+    DEPTH_COMPONENT24: [gl.DEPTH_COMPONENT, DataType.Uint32],
+    DEPTH_COMPONENT32F: [gl.DEPTH_COMPONENT, DataType.Float32],
+    DEPTH24_STENCIL8: [gl.DEPTH_STENCIL, gl.UNSIGNED_INT_24_8],
+    DEPTH32F_STENCIL8: [gl.DEPTH_STENCIL, gl.FLOAT_32_UNSIGNED_INT_24_8_REV]
+  }
+  if (capabilities.depthTexture) {
+    TextureFormat.DEPTH_COMPONENT = [gl.DEPTH_COMPONENT, DataType.Uint16]
+    TextureFormat.DEPTH_STENCIL = [gl.DEPTH_STENCIL, DataType.Uint16]
+  }
   const PixelFormat = {
-    RGBA8: 'rgba8', // gl.RGBA + gl.UNSIGNED_BYTE
-    RGBA32F: 'rgba32f', // gl.RGBA + gl.FLOAT
-    RGBA16F: 'rgba16f', // gl.RGBA + gl.HALF_FLOAT
-    R32F: 'r32f', // gl.ALPHA + gl.FLOAT
-    R16F: 'r16f', // gl.ALPHA + gl.HALF_FLOAT
-    Depth: 'depth', // gl.DEPTH_COMPONENT + gl.UNSIGNED_SHORT
-    Depth16: 'depth16', // gl.DEPTH_COMPONENT16 in renderbuffers, gl.DEPTH_COMPONENT + gl.UNSIGNED_SHORT
-    Depth24: 'depth24' // gl.DEPTH_COMPONENT + gl.UNSIGNED_INT
+    ...Object.fromEntries(
+      Object.keys(TextureFormat).map((internalFormat) => [
+        internalFormat,
+        internalFormat
+      ])
+    ),
+    // Legacy
+    Depth: 'DEPTH_COMPONENT',
+    Depth16: 'DEPTH_COMPONENT16',
+    Depth24: 'DEPTH_COMPONENT24'
   }
 
   const Encoding = {
@@ -227,6 +306,7 @@ function createContext(opts) {
     DepthFunc: DepthFunc,
     Face: Face,
     Filter: Filter,
+    TextureFormat: TextureFormat,
     PixelFormat: PixelFormat,
     Encoding: Encoding,
     Primitive: Primitive,

--- a/index.js
+++ b/index.js
@@ -147,7 +147,11 @@ function createContext(opts) {
   }
 
   const DataType = {
+    Float16: gl.HALF_FLOAT,
     Float32: gl.FLOAT,
+    Int8: gl.BYTE,
+    Int16: gl.SHORT,
+    Int32: gl.INT,
     Uint8: gl.UNSIGNED_BYTE,
     Uint16: gl.UNSIGNED_SHORT,
     Uint32: gl.UNSIGNED_INT

--- a/pass.js
+++ b/pass.js
@@ -32,7 +32,7 @@ function createPass(ctx, opts) {
     }
   }
 
-  // if color or depth targets are present assign shared framebuffer 
+  // if color or depth targets are present assign shared framebuffer
   // otherwise we will inherit framebuffer from parent command or screen
   if (opts.color || opts.depth) {
     if (!ctx.defaultState.pass.sharedFramebuffer) {

--- a/pipeline.js
+++ b/pipeline.js
@@ -42,7 +42,11 @@ function createPipeline(ctx, opts) {
       _dispose: function() {
         this.vert = null
         this.frag = null
-        if (this.program && --this.program.refCount === 0 && this.program.handle) {
+        if (
+          this.program &&
+          --this.program.refCount === 0 &&
+          this.program.handle
+        ) {
           ctx.dispose(this.program)
         }
         this.program = null

--- a/renderbuffer.js
+++ b/renderbuffer.js
@@ -29,10 +29,10 @@ function updateRenderbuffer(ctx, renderbuffer, opts) {
   const gl = ctx.gl
 
   assert(
-    renderbuffer.pixelFormat === ctx.PixelFormat.Depth16,
-    'Only PixelFormat.Depth16 is supported for renderbuffers'
+    renderbuffer.pixelFormat === ctx.PixelFormat.DEPTH_COMPONENT16,
+    'Only PixelFormat.DEPTH_COMPONENT16 is supported for renderbuffers'
   )
-  renderbuffer.format = gl.DEPTH_COMPONENT16
+  renderbuffer.format = gl[renderbuffer.pixelFormat]
 
   gl.bindRenderbuffer(renderbuffer.target, renderbuffer.handle)
   gl.renderbufferStorage(

--- a/texture.js
+++ b/texture.js
@@ -69,9 +69,9 @@ function updateTexture2D(ctx, texture, opts) {
   let min = opts.min || texture.min || gl.NEAREST
   let mag = opts.mag || texture.mag || gl.NEAREST
   let wrapS =
-    opts.wrapS || texture.wrapS || opts.wrap || texture.wrap || gl.CLAMP_TO_EDGE
+    opts.wrapS || opts.wrap || texture.wrapS || texture.wrap || gl.CLAMP_TO_EDGE
   let wrapT =
-    opts.wrapT || texture.wrapT || opts.wrap || texture.wrap || gl.CLAMP_TO_EDGE
+    opts.wrapT || opts.wrap || texture.wrapT || texture.wrap || gl.CLAMP_TO_EDGE
   let aniso = opts.aniso || texture.aniso || 0
   let premultiplyAlpha = orValue(
     opts.premultiplyAlpha,


### PR DESCRIPTION
- [x] Introduce `ctx.TextureFormat` as a mapping of `[internalFormat]: [format, type],` to automatically infer it in ctx.texture (WebGL2 ready)
- [x] Update `ctx.DataType` to be used in `ctx.TextureFormat` with signed types (WebGL2 ready)
- [x] Allow texture internalFormat/type as props (for compressed texture to pass their extension defined `internalFormat`s) 
- [x] Make pixel format match internalType (keep Depth/Depth16/Depth24 as legacy)
- [x] Check for `ctx.capabilities.depthTexture` to:
  - fallback to internalType `DEPTH_COMPONENT` instead of `DEPTH_COMPONENT16` (WEBGL_depth_texture only defines `DEPTH_COMPONENT` and `STENCIL_COMPONENT`, not `DEPTH_COMPONENT16` etc)
  - add `DEPTH_COMPONENT` and `STENCIL_COMPONENT` mapping to `ctx.TextureFormat`
- [x] Fix `premultiplyAlpha` typo, `width` instead of `height` and `opts.wrap` order issues
- [ ] Update docs


TBD:
- Allow texture internalFormat/type as props (for compressed texture to pass their extension defined `internalFormat`s):
=> Does it need to be an enum of supported compressed format instead? Or passing internalFormat is acceptable.

- Is it okay to fallback to accepted data types in `ctx.TextureFormat` eg. in case gl.HALF_FLOAT is undefined, fallback to gl.FLOAT (`R16F: [gl.RED, DataType.Float16], // DataType.Float32` could be `R16F: [gl.RED, DataType.Float16 || DataType.Float32]`)
- Any code using `ctx.PixelFormat.R32F` should be updated to:
```js
ctx.texture2D({ pixelFormat: ctx.PixelFormat.Alpha, type: ctx.DataType.Float32 })
```